### PR TITLE
DT-1982 Handle active/inactive building updates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsregisterstonomisupdate/services/CourtRegisterService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsregisterstonomisupdate/services/CourtRegisterService.kt
@@ -68,7 +68,8 @@ data class BuildingDto(
   val county: String?,
   val postcode: String?,
   val country: String?,
-  val contacts: List<ContactDto> = listOf()
+  val contacts: List<ContactDto> = listOf(),
+  val active: Boolean
 )
 
 data class ContactDto(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsregisterstonomisupdate/services/CourtRegisterUpdateService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsregisterstonomisupdate/services/CourtRegisterUpdateService.kt
@@ -360,7 +360,7 @@ class CourtRegisterUpdateService(
           primary = building == buildings[0], // first one in the list?
           noFixedAddress = false,
           startDate = LocalDate.now(),
-          endDate = if (building.active.not()) { LocalDate.now() } else { null }, // TODO updating an inactive court building will update the endDate to today - we don't have the old prison address and so cannot tell if it was already inactive
+          endDate = if (building.active.not()) { LocalDate.now() } else { null }, // Note that if we deleted and recreated the address we lose the original end date
           active = building.active,
           comment = null,
           phones = building.contacts.map { phone ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsregisterstonomisupdate/services/CourtRegisterSyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsregisterstonomisupdate/services/CourtRegisterSyncServiceTest.kt
@@ -102,7 +102,8 @@ class CourtRegisterSyncServiceTest {
         listOf(
           ContactDto(1L, "SHFCC", 1L, "TEL", "0114 1232311"),
           ContactDto(2L, "SHFCC", 1L, "FAX", "0114 1232312")
-        )
+        ),
+        true
       )
     )
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsregisterstonomisupdate/services/CourtRegisterUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsregisterstonomisupdate/services/CourtRegisterUpdateServiceTest.kt
@@ -509,7 +509,11 @@ class CourtRegisterUpdateServiceTest {
           generatePrisonCourt().copy(
             addresses = listOf(
               addressFromPrisonSystem().copy(),
-              addressFromPrisonSystem().copy(addressId = 987L, street = "second building street")
+              addressFromPrisonSystem().copy(
+                addressId = 987L,
+                street = "second building street",
+                endDate = LocalDate.now().minusDays(1)
+              )
             )
           )
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsregisterstonomisupdate/services/CourtRegisterUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsregisterstonomisupdate/services/CourtRegisterUpdateServiceTest.kt
@@ -539,7 +539,7 @@ class CourtRegisterUpdateServiceTest {
       }
 
       @Test
-      fun `prison court address NOT active - register court address NOT active - should not change prison address end date (but in fact changes it to today))`() {
+      fun `prison court address NOT active - register court address NOT active - changes prison address end date to today`() {
         whenever(prisonService.getCourtInformation(eq("SHFCC"))).thenReturn(
           generatePrisonCourt().copy(
             addresses = listOf(
@@ -568,8 +568,7 @@ class CourtRegisterUpdateServiceTest {
         verify(prisonService).insertAddress(
           eq("SHFCC"),
           check {
-            // assertThat(it.endDate).isEqualTo(LocalDate.now().minusDays(1))  TODO This assertion should be correct but we lose information from the old prison address so cannot keep its end date
-            assertThat(it.endDate).isEqualTo(LocalDate.now())
+            assertThat(it.endDate).isEqualTo(LocalDate.now()) // This is strange that we reset the end date to today but in fact we have lost the original end date - a small price to pay to avoid a crazy and complicated address matching algorithm.
           }
         )
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsregisterstonomisupdate/services/CourtRegisterUpdateServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsregisterstonomisupdate/services/CourtRegisterUpdateServiceTest.kt
@@ -2,11 +2,15 @@ package uk.gov.justice.digital.hmpps.hmppsregisterstonomisupdate.services
 
 import com.microsoft.applicationinsights.TelemetryClient
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.check
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsregisterstonomisupdate.config.GsonConfig
 import uk.gov.justice.digital.hmpps.hmppsregisterstonomisupdate.model.CourtUpdate
@@ -23,7 +27,14 @@ class CourtRegisterUpdateServiceTest {
 
   @BeforeEach
   fun before() {
-    service = CourtRegisterUpdateService(courtRegisterService, prisonService, prisonReferenceDataService, telemetryClient, true, GsonConfig().gson())
+    service = CourtRegisterUpdateService(
+      courtRegisterService,
+      prisonService,
+      prisonReferenceDataService,
+      telemetryClient,
+      true,
+      GsonConfig().gson()
+    )
 
     whenever(prisonReferenceDataService.getRefCode(eq("ADDR_TYPE"), eq("Business Address"), eq(false))).thenReturn(
       ReferenceCode("ADDR_TYPE", "BUS", "Business Address", "Y", null)
@@ -74,8 +85,20 @@ class CourtRegisterUpdateServiceTest {
         listOf(
           addressFromPrisonSystem(),
           AddressFromPrisonSystem(
-            57L, "Business Address", null, "Another Sheffield Court Building - Part of main", "Law Street", "Kelham Island", "Sheffield",
-            "S1 5TT", "South Yorkshire", "England", false, false, LocalDate.now(), null,
+            57L,
+            "Business Address",
+            null,
+            "Another Sheffield Court Building - Part of main",
+            "Law Street",
+            "Kelham Island",
+            "Sheffield",
+            "S1 5TT",
+            "South Yorkshire",
+            "England",
+            false,
+            false,
+            LocalDate.now(),
+            null,
             listOf(PhoneFromPrisonSystem(22432L, "0114 1232318", "BUS", null))
           )
         )
@@ -129,8 +152,20 @@ class CourtRegisterUpdateServiceTest {
         listOf(
           addressFromPrisonSystem(),
           AddressFromPrisonSystem(
-            57L, "Business Address", null, "Another Sheffield Court Building - Part of main", "Law Street", "Kelham Island", "Sheffield",
-            "S1 5TT", "South Yorkshire", "England", false, false, LocalDate.now(), null,
+            57L,
+            "Business Address",
+            null,
+            "Another Sheffield Court Building - Part of main",
+            "Law Street",
+            "Kelham Island",
+            "Sheffield",
+            "S1 5TT",
+            "South Yorkshire",
+            "England",
+            false,
+            false,
+            LocalDate.now(),
+            null,
             listOf(PhoneFromPrisonSystem(22432L, "0114 1232318", "BUS", null))
           )
         )
@@ -229,7 +264,10 @@ class CourtRegisterUpdateServiceTest {
           AddressFromPrisonSystem(
             56L, "Business Address", null, "Main Sheffield Court Building", "Law Street", "Kelham Island", "Sheffield",
             "S1 5TT", "South Yorkshire", "England", true, false, LocalDate.now(), null,
-            listOf(PhoneFromPrisonSystem(23432L, "0114 1232311", "BUS", null), PhoneFromPrisonSystem(23437L, "0114 1232317", "FAX", null))
+            listOf(
+              PhoneFromPrisonSystem(23432L, "0114 1232311", "BUS", null),
+              PhoneFromPrisonSystem(23437L, "0114 1232317", "FAX", null)
+            )
           )
         )
       )
@@ -256,8 +294,20 @@ class CourtRegisterUpdateServiceTest {
         "Sheffield Crown Court in Sheffield", "CRT", true, "CC", null,
         listOf(
           AddressFromPrisonSystem(
-            56L, "Business Address", null, "Main Sheffield Court Building", "Lawson Street", "Kelham Island", "Sheffield",
-            "S1 5TT", "South Yorkshire", "England", true, false, LocalDate.now(), null,
+            56L,
+            "Business Address",
+            null,
+            "Main Sheffield Court Building",
+            "Lawson Street",
+            "Kelham Island",
+            "Sheffield",
+            "S1 5TT",
+            "South Yorkshire",
+            "England",
+            true,
+            false,
+            LocalDate.now(),
+            null,
             phoneList()
           )
         )
@@ -276,114 +326,391 @@ class CourtRegisterUpdateServiceTest {
     assertThat(courtStats.numberAddressesUpdated).isEqualTo(1)
   }
 
-  private fun addressFromPrisonSystem() =
-    AddressFromPrisonSystem(
-      56L, "Business Address", null, "Main Sheffield Court Building", "Law Street", "Kelham Island", "Sheffield",
-      "S1 5TT", "South Yorkshire", "England", true, false, LocalDate.now(), null,
-      phoneList()
-    )
+  @Nested
+  inner class ActiveBuildings {
 
-  private fun phoneList() =
-    listOf(
-      PhoneFromPrisonSystem(23432L, "0114 1232311", "BUS", null),
-      PhoneFromPrisonSystem(23437L, "0114 1232312", "FAX", null)
-    )
+    @Nested
+    inner class SingleExistingBuilding {
 
-  private fun generateCourtRegisterEntry() = CourtDto(
-    "SHFCC",
-    "Sheffield Crown Court",
-    "Sheffield Crown Court in Sheffield",
-    CourtTypeDto("CRN", "Crown Court"),
-    true,
-    listOf(
-      BuildingDto(
-        1L,
-        "SHFCC",
-        null,
-        "Main Sheffield Court Building",
-        "Law Street",
-        "Kelham Island",
-        "Sheffield",
-        "South Yorkshire",
-        "S1 5TT",
-        "England",
-        listOf(
-          ContactDto(1L, "SHFCC", 1L, "TEL", "0114 1232311"),
-          ContactDto(2L, "SHFCC", 1L, "FAX", "0114 1232312")
+      @Test
+      fun `prison court address active - register court address active - should NOT change prison address end date`() {
+        whenever(prisonService.getCourtInformation(eq("SHFCC"))).thenReturn(generatePrisonCourt())
+        whenever(courtRegisterService.getCourtInfoFromRegister(eq("SHFCC"))).thenReturn(
+          generateCourtRegisterEntry().copy(courtName = "new court name")
         )
-      )
-    )
-  )
 
-  private fun generateCourtRegisterEntryMultipleLocations() = CourtDto(
-    "SHFCC",
-    "Sheffield Crown Court",
-    "Sheffield Crown Court in Sheffield",
-    CourtTypeDto("CRN", "Crown Court"),
-    true,
-    listOf(
-      BuildingDto(
-        1L,
-        "SHFCC",
-        null,
-        "Main Sheffield Court Building",
-        "Law Street",
-        "Kelham Island",
-        "Sheffield",
-        "South Yorkshire",
-        "S1 5TT",
-        "England",
-        listOf(
-          ContactDto(1L, "SHFCC", 1L, "TEL", "0114 1232311"),
-          ContactDto(2L, "SHFCC", 1L, "FAX", "0114 1232312")
+        service.updateCourtDetails(CourtUpdate("SHFCC"))
+
+        verify(prisonService).updateCourt(
+          check {
+            assertThat(it.addresses[0].endDate).isNull()
+          }
         )
-      ),
-      BuildingDto(
-        11L,
-        "SHFCC",
-        "SHFCC1",
-        "Annex 1",
-        "Law Street",
-        "Kelham Island",
-        "Sheffield",
-        "South Yorkshire",
-        "S1 5TT",
-        "England",
-        listOf(
-          ContactDto(12L, "SHFCC", 11L, "TEL", "0114 1232812")
+      }
+
+      @Test
+      fun `prison court address NOT active - register court address NOT active - should not change prison address end date`() {
+        whenever(prisonService.getCourtInformation(eq("SHFCC"))).thenReturn(
+          generatePrisonCourt().copy(
+            addresses = listOf(
+              addressFromPrisonSystem().copy(endDate = LocalDate.now().minusDays(1))
+            )
+          )
         )
-      ),
-      BuildingDto(
-        31L,
-        "SHFCC",
-        "SHFCC2",
-        "Queen Mary Court Annex 2",
-        "Law Street",
-        "Kelham Island",
-        "Sheffield",
-        "South Yorkshire",
-        "S1 5TT",
-        "England",
-        listOf(
-          ContactDto(31L, "SHFCC", 31L, "TEL", "0114 1932311"),
-          ContactDto(32L, "SHFCC", 31L, "FAX", "0114 1932312")
+        whenever(courtRegisterService.getCourtInfoFromRegister(eq("SHFCC"))).thenReturn(
+          generateCourtRegisterEntry()
+            .copy(courtName = "new court name", buildings = listOf(addressFromCourtRegister().copy(active = false)))
         )
-      ),
-      BuildingDto(
-        41L,
-        "SHFCC",
-        null,
-        "Another Sheffield Court Building - Part of main",
-        "Law Street",
-        "Kelham Island",
-        "Sheffield",
-        "South Yorkshire",
-        "S1 5TT",
-        "England",
-        listOf(
-          ContactDto(41L, "SHFCC", 41L, "TEL", "0114 1232318"),
+
+        service.updateCourtDetails(CourtUpdate("SHFCC"))
+
+        verify(prisonService).updateCourt(
+          check {
+            assertThat(it.addresses[0].endDate).isEqualTo(LocalDate.now().minusDays(1))
+          }
         )
-      )
-    )
-  )
+      }
+
+      @Test
+      fun `prison court address active - register court address NOT active - should set prison address end date`() {
+        whenever(prisonService.getCourtInformation(eq("SHFCC"))).thenReturn(generatePrisonCourt())
+        whenever(courtRegisterService.getCourtInfoFromRegister(eq("SHFCC"))).thenReturn(
+          generateCourtRegisterEntry()
+            .copy(courtName = "new court name", buildings = listOf(addressFromCourtRegister().copy(active = false)))
+        )
+
+        service.updateCourtDetails(CourtUpdate("SHFCC"))
+
+        verify(prisonService).updateCourt(
+          check {
+            assertThat(it.addresses[0].endDate).isEqualTo(LocalDate.now())
+          }
+        )
+      }
+
+      @Test
+      fun `prison court address NOT active - register court address active - should set prison address end date null`() {
+        whenever(prisonService.getCourtInformation(eq("SHFCC"))).thenReturn(
+          generatePrisonCourt().copy(
+            addresses = listOf(
+              addressFromPrisonSystem().copy(endDate = LocalDate.now().minusDays(1))
+            )
+          )
+        )
+        whenever(courtRegisterService.getCourtInfoFromRegister(eq("SHFCC"))).thenReturn(
+          generateCourtRegisterEntry().copy(courtName = "new court name")
+        )
+
+        service.updateCourtDetails(CourtUpdate("SHFCC"))
+
+        verify(prisonService).updateCourt(
+          check {
+            assertThat(it.addresses[0].endDate).isNull()
+          }
+        )
+      }
+    }
+
+    @Nested
+    inner class NewBuildingAdded {
+
+      @Test
+      fun `new register court address active - should set NEW prison address end date null`() {
+        whenever(prisonService.getCourtInformation(eq("SHFCC"))).thenReturn(generatePrisonCourt())
+        whenever(courtRegisterService.getCourtInfoFromRegister(eq("SHFCC"))).thenReturn(
+          generateCourtRegisterEntry()
+            .copy(
+              buildings = listOf(
+                addressFromCourtRegister().copy(),
+                addressFromCourtRegister().copy(street = "New building street")
+              )
+            )
+        )
+
+        service.updateCourtDetails(CourtUpdate("SHFCC"))
+
+        verify(prisonService).insertAddress(
+          eq("SHFCC"),
+          check {
+            assertThat(it.endDate).isNull()
+          }
+        )
+      }
+    }
+
+    @Nested
+    inner class MultipleExistingBuildings {
+
+      @Test
+      fun `prison court address active - register court address active - should not change prison address end date`() {
+        whenever(prisonService.getCourtInformation(eq("SHFCC"))).thenReturn(
+          generatePrisonCourt().copy(
+            addresses = listOf(
+              addressFromPrisonSystem().copy(),
+              addressFromPrisonSystem().copy(addressId = 987L, street = "second building street")
+            )
+          )
+        )
+        whenever(courtRegisterService.getCourtInfoFromRegister(eq("SHFCC"))).thenReturn(
+          generateCourtRegisterEntry()
+            .copy(
+              buildings = listOf(
+                addressFromCourtRegister().copy(),
+                addressFromCourtRegister().copy(street = "second building street has changed")
+              )
+            )
+        )
+
+        service.updateCourtDetails(CourtUpdate("SHFCC"))
+
+        verify(prisonService).removeAddress("SHFCC", 987L)
+        verify(prisonService).insertAddress(
+          eq("SHFCC"),
+          check {
+            assertThat(it.endDate).isNull()
+          }
+        )
+      }
+
+      @Test
+      fun `prison court address active - register court address NOT active - should change prison address end date to today`() {
+        whenever(prisonService.getCourtInformation(eq("SHFCC"))).thenReturn(
+          generatePrisonCourt().copy(
+            addresses = listOf(
+              addressFromPrisonSystem().copy(),
+              addressFromPrisonSystem().copy(addressId = 987L, street = "second building street")
+            )
+          )
+        )
+        whenever(courtRegisterService.getCourtInfoFromRegister(eq("SHFCC"))).thenReturn(
+          generateCourtRegisterEntry()
+            .copy(
+              buildings = listOf(
+                addressFromCourtRegister().copy(),
+                addressFromCourtRegister().copy(street = "second building street has changed", active = false)
+              )
+            )
+        )
+
+        service.updateCourtDetails(CourtUpdate("SHFCC"))
+
+        verify(prisonService).removeAddress("SHFCC", 987L)
+        verify(prisonService).insertAddress(
+          eq("SHFCC"),
+          check {
+            assertThat(it.endDate).isEqualTo(LocalDate.now())
+          }
+        )
+      }
+
+      @Test
+      fun `prison court address NOT active - register court address active - should change prison address end date to null`() {
+        whenever(prisonService.getCourtInformation(eq("SHFCC"))).thenReturn(
+          generatePrisonCourt().copy(
+            addresses = listOf(
+              addressFromPrisonSystem().copy(),
+              addressFromPrisonSystem().copy(addressId = 987L, street = "second building street")
+            )
+          )
+        )
+        whenever(courtRegisterService.getCourtInfoFromRegister(eq("SHFCC"))).thenReturn(
+          generateCourtRegisterEntry()
+            .copy(
+              buildings = listOf(
+                addressFromCourtRegister().copy(),
+                addressFromCourtRegister().copy(street = "second building street has changed")
+              )
+            )
+        )
+
+        service.updateCourtDetails(CourtUpdate("SHFCC"))
+
+        verify(prisonService).removeAddress("SHFCC", 987L)
+        verify(prisonService).insertAddress(
+          eq("SHFCC"),
+          check {
+            assertThat(it.endDate).isNull()
+          }
+        )
+      }
+
+      @Test
+      fun `prison court address NOT active - register court address NOT active - should not change prison address end date (but in fact changes it to today))`() {
+        whenever(prisonService.getCourtInformation(eq("SHFCC"))).thenReturn(
+          generatePrisonCourt().copy(
+            addresses = listOf(
+              addressFromPrisonSystem().copy(),
+              addressFromPrisonSystem().copy(
+                addressId = 987L,
+                street = "second building street",
+                endDate = LocalDate.now().minusDays(1)
+              )
+            )
+          )
+        )
+        whenever(courtRegisterService.getCourtInfoFromRegister(eq("SHFCC"))).thenReturn(
+          generateCourtRegisterEntry()
+            .copy(
+              buildings = listOf(
+                addressFromCourtRegister().copy(),
+                addressFromCourtRegister().copy(street = "second building street has changed", active = false)
+              )
+            )
+        )
+
+        service.updateCourtDetails(CourtUpdate("SHFCC"))
+
+        verify(prisonService).removeAddress("SHFCC", 987L)
+        verify(prisonService).insertAddress(
+          eq("SHFCC"),
+          check {
+            // assertThat(it.endDate).isEqualTo(LocalDate.now().minusDays(1))  TODO This assertion should be correct but we lose information from the old prison address so cannot keep its end date
+            assertThat(it.endDate).isEqualTo(LocalDate.now())
+          }
+        )
+      }
+    }
+  }
 }
+
+private fun addressFromPrisonSystem() =
+  AddressFromPrisonSystem(
+    56L, "Business Address", null, "Main Sheffield Court Building", "Law Street", "Kelham Island", "Sheffield",
+    "S1 5TT", "South Yorkshire", "England", true, false, LocalDate.now(), null,
+    phoneList()
+  )
+
+private fun addressFromCourtRegister() =
+  BuildingDto(
+    1L,
+    "SHFCC",
+    null,
+    "Main Sheffield Court Building",
+    "Law Street",
+    "Kelham Island",
+    "Sheffield",
+    "South Yorkshire",
+    "S1 5TT",
+    "England",
+    listOf(
+      ContactDto(1L, "SHFCC", 1L, "TEL", "0114 1232311"),
+      ContactDto(2L, "SHFCC", 1L, "FAX", "0114 1232312")
+    ),
+    true
+  )
+
+private fun phoneList() =
+  listOf(
+    PhoneFromPrisonSystem(23432L, "0114 1232311", "BUS", null),
+    PhoneFromPrisonSystem(23437L, "0114 1232312", "FAX", null)
+  )
+
+private fun generatePrisonCourt() =
+  CourtFromPrisonSystem(
+    "SHFCC", "Sheffield Crown Court",
+    "Sheffield Crown Court in Sheffield", "CRT", true, "CC", null,
+    listOf(addressFromPrisonSystem())
+  )
+
+private fun generateCourtRegisterEntry() = CourtDto(
+  "SHFCC",
+  "Sheffield Crown Court",
+  "Sheffield Crown Court in Sheffield",
+  CourtTypeDto("CRN", "Crown Court"),
+  true,
+  listOf(
+    BuildingDto(
+      1L,
+      "SHFCC",
+      null,
+      "Main Sheffield Court Building",
+      "Law Street",
+      "Kelham Island",
+      "Sheffield",
+      "South Yorkshire",
+      "S1 5TT",
+      "England",
+      listOf(
+        ContactDto(1L, "SHFCC", 1L, "TEL", "0114 1232311"),
+        ContactDto(2L, "SHFCC", 1L, "FAX", "0114 1232312")
+      ),
+      true
+    )
+  )
+)
+
+private fun generateCourtRegisterEntryMultipleLocations() = CourtDto(
+  "SHFCC",
+  "Sheffield Crown Court",
+  "Sheffield Crown Court in Sheffield",
+  CourtTypeDto("CRN", "Crown Court"),
+  true,
+  listOf(
+    BuildingDto(
+      1L,
+      "SHFCC",
+      null,
+      "Main Sheffield Court Building",
+      "Law Street",
+      "Kelham Island",
+      "Sheffield",
+      "South Yorkshire",
+      "S1 5TT",
+      "England",
+      listOf(
+        ContactDto(1L, "SHFCC", 1L, "TEL", "0114 1232311"),
+        ContactDto(2L, "SHFCC", 1L, "FAX", "0114 1232312")
+      ),
+      true
+    ),
+    BuildingDto(
+      11L,
+      "SHFCC",
+      "SHFCC1",
+      "Annex 1",
+      "Law Street",
+      "Kelham Island",
+      "Sheffield",
+      "South Yorkshire",
+      "S1 5TT",
+      "England",
+      listOf(
+        ContactDto(12L, "SHFCC", 11L, "TEL", "0114 1232812")
+      ),
+      true
+    ),
+    BuildingDto(
+      31L,
+      "SHFCC",
+      "SHFCC2",
+      "Queen Mary Court Annex 2",
+      "Law Street",
+      "Kelham Island",
+      "Sheffield",
+      "South Yorkshire",
+      "S1 5TT",
+      "England",
+      listOf(
+        ContactDto(31L, "SHFCC", 31L, "TEL", "0114 1932311"),
+        ContactDto(32L, "SHFCC", 31L, "FAX", "0114 1932312")
+      ),
+      true
+    ),
+    BuildingDto(
+      41L,
+      "SHFCC",
+      null,
+      "Another Sheffield Court Building - Part of main",
+      "Law Street",
+      "Kelham Island",
+      "Sheffield",
+      "South Yorkshire",
+      "S1 5TT",
+      "England",
+      listOf(
+        ContactDto(41L, "SHFCC", 41L, "TEL", "0114 1232318"),
+      ),
+      true
+    )
+  )
+)


### PR DESCRIPTION
There is 1 issue with these changes that doesn't quite work - hence the draft PR.

If we have multiple buildings and some have changed, the current sync processing deletes the old prison address and creates a new one (it's not possible to match prison addresses and court buildings in that case).  Fair enough.

However, this means that if we update an inactive building, as we do not know which Nomis address has been updated we lose any information about its end date - and we end up resetting the end date to today.

As far as I'm concerned it's an edge case that doesn't cause major issues - the Nomis address is still inactive and we lose an uninteresting piece of data, the true date the address was closed.  So I can live with it but would appreciate other opinions.

UPDATE: Everyone agrees the edge case is not worth worrying about.  It's not even possible to do that in the registers UI as active flag is updated independently of the main address details.